### PR TITLE
[Fix] doctrine:migration:version usage of --no-interaction option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@ Changelog
 This changelog references the relevant changes (evolution, bug and security fixes)
 
 * 1.0.2
-    * Ask for console file path on install scriptHandler (prepare for Sf3)
+
+    * Fix doctrine:migration:version usage of --no-interaction option which only work on CLI mode
     
 * 1.0.1
     
-    * Add Grunt file and command for build
+    * Add Grunt & Bower files and command for build
+    * Ask for console file path on install scriptHandler (prepare for Sf3)
+    * Fix releaser excludes /build/ directories instead of ./build
+
+* 1.0.0
+
+    * First stable release

--- a/Command/InstallCommand.php
+++ b/Command/InstallCommand.php
@@ -98,9 +98,10 @@ class InstallCommand extends AbstractDeploymentCommand
         $commandInput = new ArrayInput(array(
             'command'           => 'doctrine:migration:version',
             '--add'             => true,
-            '--all'             => true,
-            '--no-interaction'  => true
+            '--all'             => true
         ));
+        // Replace --no-interaction option which only work on CLI mode
+        $commandInput->setInteractive(false);
         $application->doRun($commandInput, $this->output);
 
         $this->log('Set all migration as executed done..');


### PR DESCRIPTION
[Fix] doctrine:migration:version usage of --no-interaction option which only work on CLI mode